### PR TITLE
Power State Optimisations + Bulb Characteristics

### DIFF
--- a/src/LightBulbAccessory.ts
+++ b/src/LightBulbAccessory.ts
@@ -44,7 +44,10 @@ export default class LightBulbAccessory {
     private readonly accessory: PlatformAccessory<Context>,
     private readonly log: Logger,
     public readonly model: string,
-    public readonly mac: string
+    public readonly mac: string,
+    public readonly supportsColorTemp: boolean,
+    public readonly supportsHue: boolean,
+    public readonly supportsSaturation: boolean
   ) {
     this.tpLink = accessory.context.tpLink;
 
@@ -71,30 +74,38 @@ export default class LightBulbAccessory {
       .onGet(Brightness.get.bind(this))
       .onSet(Brightness.set.bind(this));
 
-    this.service
-      .getCharacteristic(this.platform.Characteristic.ColorTemperature)
-      .setProps({
-        minValue: HOME_KIT_VALUES.min,
-        maxValue: HOME_KIT_VALUES.max
-      })
-      .onGet(ColorTemperature.get.bind(this))
-      .onSet(ColorTemperature.set.bind(this));
+    if (supportsColorTemp == true) {
+      this.service
+        .getCharacteristic(this.platform.Characteristic.ColorTemperature)
+        .setProps({
+          minValue: HOME_KIT_VALUES.min,
+          maxValue: HOME_KIT_VALUES.max
+        })
+        .onGet(ColorTemperature.get.bind(this))
+        .onSet(ColorTemperature.set.bind(this));
+    }
 
-    this.service
-      .getCharacteristic(this.platform.Characteristic.Hue)
-      .onGet(Hue.get.bind(this))
-      .onSet(Hue.set.bind(this));
+    if (supportsHue == true) {
+      this.service
+        .getCharacteristic(this.platform.Characteristic.Hue)
+        .onGet(Hue.get.bind(this))
+        .onSet(Hue.set.bind(this));
+    }
 
-    this.service
-      .getCharacteristic(this.platform.Characteristic.Saturation)
-      .onGet(Saturation.get.bind(this))
-      .onSet(Saturation.set.bind(this));
+    if (supportsSaturation == true) {
+      this.service
+        .getCharacteristic(this.platform.Characteristic.Saturation)
+        .onGet(Saturation.get.bind(this))
+        .onSet(Saturation.set.bind(this));
+    }
 
-    const adaptiveLightingController =
-      new this.platform.api.hap.AdaptiveLightingController(this.service, {
-        controllerMode:
-          this.platform.api.hap.AdaptiveLightingControllerMode.AUTOMATIC
-      });
+    if (supportsColorTemp == true && supportsHue == true && supportsSaturation == true) {
+      const adaptiveLightingController =
+        new this.platform.api.hap.AdaptiveLightingController(this.service, {
+          controllerMode:
+            this.platform.api.hap.AdaptiveLightingControllerMode.AUTOMATIC
+        });
+    }
 
     this.accessory.configureController(adaptiveLightingController);
   }

--- a/src/api/TPLink.ts
+++ b/src/api/TPLink.ts
@@ -86,6 +86,9 @@ export default class TPLink {
     command: T,
     ...args: Parameters<Commands[T]>
   ): Promise<CommandReturnType<T>> {
+    if (command === 'power' && this._prevPowerState == args[0]) {
+      return
+    }
     return this.lock.acquire(
       'send-command',
       (): Promise<CommandReturnType<T>> => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -102,6 +102,9 @@ export default class Platform implements DynamicPlatformPlugin {
       const deviceName = Buffer.from(deviceInfo.nickname, 'base64').toString(
         'utf-8'
       );
+      const supportsColorTemp = (deviceInfo.color_temp != undefined);
+      const supportsHue = (deviceInfo.hue != undefined);
+      const supportsSaturation = (deviceInfo.saturation != undefined);
 
       const existingAccessory = this.accessories.find(
         (accessory) => accessory.UUID === uuid
@@ -123,7 +126,10 @@ export default class Platform implements DynamicPlatformPlugin {
             existingAccessory,
             this.log,
             deviceInfo.model,
-            deviceInfo.mac
+            deviceInfo.mac,
+            supportsColorTemp,
+            supportsHue,
+            supportsSaturation
           )
         );
         return;
@@ -145,7 +151,10 @@ export default class Platform implements DynamicPlatformPlugin {
           accessory,
           this.log,
           deviceInfo.model,
-          deviceInfo.mac
+          deviceInfo.mac,
+          supportsColorTemp,
+          supportsHue,
+          supportsSaturation
         )
       );
 


### PR DESCRIPTION
- Prevent sending power state if it matches the current state. HomeKit sends both power and brightness when changing bulb brightness, which leads to flickering.
- Checks if bulb supports colorTemp, hue, saturation before registering characteristics